### PR TITLE
Rename "Recent Commits" to "CI Build Commits".

### DIFF
--- a/public/javascripts/dashboard.js
+++ b/public/javascripts/dashboard.js
@@ -304,7 +304,7 @@ var RecentCommits = React.createClass({
         </g>
         </svg>
           <h2>
-            Recent Commits
+            CI Build Commits
           </h2>
         </header>
         <ul className="commitMsgs">


### PR DESCRIPTION
I would suggest to rename the "Recent Commits" heading on the dashboard to "CI Build Commits", because only the changes of a finished build are shown on the board.
